### PR TITLE
Add designs directory for design reference files

### DIFF
--- a/designs/README.md
+++ b/designs/README.md
@@ -1,0 +1,20 @@
+# Design References
+
+This directory contains design screenshots and references for the EKR Construction website.
+
+## Contents
+
+- Section designs (hero, services, about, contact, etc.)
+- Component designs (buttons, cards, forms, etc.)
+- Layout screenshots
+- Design inspiration and references
+
+## Notes
+
+- Files here are for development reference only
+- Not included in production build
+- Add descriptive filenames (e.g., `hero-section.png`, `contact-form.jpg`)
+
+## Usage
+
+Developers should reference these designs when implementing sections and components to ensure design fidelity.


### PR DESCRIPTION
Created /designs directory to store design screenshots and references. This directory is for development reference only and is not included in the production build.

Developers can reference designs here when implementing sections and components.